### PR TITLE
Title Screen Module

### DIFF
--- a/coilsnake/assets/modulelist.txt
+++ b/coilsnake/assets/modulelist.txt
@@ -22,5 +22,6 @@ eb.BattleBgModule
 eb.CompressedGraphicsModule
 eb.EnemyModule
 eb.TilesetModule
+eb.TitleScreenModule
 smb.TextModule
 common.LunarIpsCompatibilityModule

--- a/coilsnake/assets/modulelist.txt
+++ b/coilsnake/assets/modulelist.txt
@@ -21,7 +21,7 @@ eb.WindowGraphicsModule
 eb.BattleBgModule
 eb.CompressedGraphicsModule
 eb.EnemyModule
-eb.TilesetModule
 eb.TitleScreenModule
+eb.TilesetModule
 smb.TextModule
 common.LunarIpsCompatibilityModule

--- a/coilsnake/model/eb/graphics.py
+++ b/coilsnake/model/eb/graphics.py
@@ -127,10 +127,11 @@ class EbGraphicTileset(EqualityMixin):
                         image_y += 1
                     already_read_tiles.add(arrangement_item.tile)
 
-    def add_tile(self, tile):
+    def add_tile(self, tile, no_flip=False):
         """Adds a tile into this tileset if the tileset does not already contain it.
 
         :param tile: the tile to add, as a two-dimensional list
+        :param no_flip: don't store any flips of this tile
         :return: a tuple containing the tile's id in this tileset, whether the tile is stored as vertically flipped,
         and whether the tile is stored as horizontally flipped"""
 
@@ -150,6 +151,10 @@ class EbGraphicTileset(EqualityMixin):
         tile_id = self._num_tiles_used
         self.tiles.append(tile_copy)
         self._num_tiles_used += 1
+
+        if no_flip:
+            self._used_tiles[tile_hash] = tile_id, False, False
+            return tile_id, False, False
 
         # The tile will be stored as horizontally flipped
         self._used_tiles[tile_hash] = tile_id, False, True
@@ -276,9 +281,9 @@ class EbTileArrangement(EqualityMixin):
         self.to_image(image, tileset, palette)
         return image
 
-    def from_image(self, image, tileset, palette):
+    def from_image(self, image, tileset, palette, no_flip=False):
         if palette.num_subpalettes == 1:
-            self._from_image_with_single_subpalette(image, tileset, palette)
+            self._from_image_with_single_subpalette(image, tileset, palette, no_flip)
         else:
             # Multiple subpalettes, so we have to figure out which tile should use which subpalette
             palette.from_image(image)
@@ -317,7 +322,7 @@ class EbTileArrangement(EqualityMixin):
                             tile[tile_y][tile_x] = palette.get_color_id(rgb_image_data[image_tile_x, image_tile_y],
                                                                         subpalette_id)
 
-                    tile_id, vflip, hflip = tileset.add_tile(tile)
+                    tile_id, vflip, hflip = tileset.add_tile(tile, no_flip)
                     arrangement_item = self.arrangement[arrangement_y][arrangement_x]
                     arrangement_item.tile = tile_id
                     arrangement_item.subpalette = subpalette_id
@@ -325,7 +330,7 @@ class EbTileArrangement(EqualityMixin):
                     arrangement_item.is_horizontally_flipped = hflip
                     arrangement_item.is_priority = False
 
-    def _from_image_with_single_subpalette(self, image, tileset, palette):
+    def _from_image_with_single_subpalette(self, image, tileset, palette, no_flip=False):
         # Don't need to do any subpalette fitting because there's only one subpalette
         palette.from_image(image)
         image_data = image.load()
@@ -343,7 +348,7 @@ class EbTileArrangement(EqualityMixin):
                     for tile_x in xrange(tileset.tile_width):
                         tile_row[tile_x] = image_data[image_x + tile_x, image_tile_y]
 
-                tile_id, vflip, hflip = tileset.add_tile(tile)
+                tile_id, vflip, hflip = tileset.add_tile(tile, no_flip)
                 arrangement_item = self.arrangement[arrangement_y][arrangement_x]
                 arrangement_item.tile = tile_id
                 arrangement_item.subpalette = 0

--- a/coilsnake/model/eb/palettes.py
+++ b/coilsnake/model/eb/palettes.py
@@ -245,9 +245,7 @@ class EbPalette(EqualityMixin):
     def __getitem__(self, key):
         subpalette_number, color_number = key
         if subpalette_number < 0 or subpalette_number >= self.num_subpalettes \
-                or (isinstance(color_number, int) and (color_number < 0 or color_number >= self.subpalette_length)) \
-                or (isinstance(color_number, slice) and (color_number.start < 0 or color_number.start >= self.subpalette_length
-                    or color_number.stop < 0 or color_number.stop >= self.subpalette_length)):
+                or (isinstance(color_number, int) and (color_number < 0 or color_number >= self.subpalette_length)):
             raise InvalidArgumentError("Could not get color[{},{}] from palette of size[{},{}]".format(
                 subpalette_number, color_number, self.num_subpalettes, self.subpalette_length))
         return self.subpalettes[subpalette_number][color_number]
@@ -255,9 +253,7 @@ class EbPalette(EqualityMixin):
     def __setitem__(self, key, item):
         subpalette_number, color_number = key
         if subpalette_number < 0 or subpalette_number >= self.num_subpalettes \
-                or (isinstance(color_number, int) and (color_number < 0 or color_number >= self.subpalette_length)) \
-                or (isinstance(color_number, slice) and (color_number.start < 0 or color_number.start >= self.subpalette_length
-                    or color_number.stop < 0 or color_number.stop >= self.subpalette_length)):
+                or (isinstance(color_number, int) and (color_number < 0 or color_number >= self.subpalette_length)):
             raise InvalidArgumentError("Could not set color[{},{}] of palette of size[{},{}]".format(
                 subpalette_number, color_number, self.num_subpalettes, self.subpalette_length))
 

--- a/coilsnake/model/eb/palettes.py
+++ b/coilsnake/model/eb/palettes.py
@@ -244,11 +244,24 @@ class EbPalette(EqualityMixin):
 
     def __getitem__(self, key):
         subpalette_number, color_number = key
-        if subpalette_number < 0 or color_number < 0 or subpalette_number >= self.num_subpalettes \
-                or color_number >= self.subpalette_length:
+        if subpalette_number < 0 or subpalette_number >= self.num_subpalettes \
+                or (isinstance(color_number, int) and (color_number < 0 or color_number >= self.subpalette_length)) \
+                or (isinstance(color_number, slice) and (color_number.start < 0 or color_number.start >= self.subpalette_length
+                    or color_number.stop < 0 or color_number.stop >= self.subpalette_length)):
             raise InvalidArgumentError("Could not get color[{},{}] from palette of size[{},{}]".format(
                 subpalette_number, color_number, self.num_subpalettes, self.subpalette_length))
         return self.subpalettes[subpalette_number][color_number]
+
+    def __setitem__(self, key, item):
+        subpalette_number, color_number = key
+        if subpalette_number < 0 or subpalette_number >= self.num_subpalettes \
+                or (isinstance(color_number, int) and (color_number < 0 or color_number >= self.subpalette_length)) \
+                or (isinstance(color_number, slice) and (color_number.start < 0 or color_number.start >= self.subpalette_length
+                    or color_number.stop < 0 or color_number.stop >= self.subpalette_length)):
+            raise InvalidArgumentError("Could not set color[{},{}] of palette of size[{},{}]".format(
+                subpalette_number, color_number, self.num_subpalettes, self.subpalette_length))
+
+        self.subpalettes[subpalette_number][color_number] = item
 
     def hash(self):
         a = array('B', self.list())

--- a/coilsnake/model/eb/title_screen.py
+++ b/coilsnake/model/eb/title_screen.py
@@ -1,0 +1,61 @@
+CHARS_NUM_TILES = 1024
+
+
+class TitleScreenLayoutEntry(object):
+
+    SINGLE_FLAG = 0x01
+    FINAL_FLAG = 0x80
+
+    def __init__(self, x=0, y=0, tile=0, flags=0, unknown=12):
+        self.x = x
+        self.y = y
+        self.tile = tile
+        self.flags = flags
+        self.unknown = unknown
+
+    def from_block(self, block, offset=0):
+        y = block[offset]
+        self.y = y if y < 128 else -(256-y)  # Read signed value
+        tile_bytes = block.read_multi(offset+1, 2)
+        self.tile = tile_bytes & (CHARS_NUM_TILES - 1)
+        self.unknown = tile_bytes >> (CHARS_NUM_TILES - 1).bit_length()
+        x = block[offset+3]
+        self.x = x if x < 128 else -(256-x)  # Read signed value
+        self.flags = block[offset+4]
+
+    def to_block(self, block, offset=0):
+        block[offset] = self.y if self.y >= 0 else self.y+256
+        block.write_multi(
+            offset+1,
+            self.tile | self.unknown << (CHARS_NUM_TILES - 1).bit_length(), 2
+        )
+        block[offset+3] = self.x if self.x >= 0 else self.x+256
+        block[offset+4] = self.flags
+
+    @staticmethod
+    def block_size():
+        return 5
+
+    def is_single(self):
+        return (self.flags & self.SINGLE_FLAG) == 0
+
+    def set_single(self, single=True):
+        if single:
+            self.flags |= self.SINGLE_FLAG
+        else:
+            self.flags &= ~self.SINGLE_FLAG
+
+    def is_final(self):
+        return (self.flags & self.FINAL_FLAG) != 0
+
+    def set_final(self, final=True):
+        if final:
+            self.flags |= self.FINAL_FLAG
+        else:
+            self.flags &= ~self.FINAL_FLAG
+
+    def __str__(self):
+        return "<tile={}, x={}, y={}, flags={}, unknown={}>".format(
+            self.tile & (CHARS_NUM_TILES - 1), self.x, self.y,
+            bin(self.flags)[2:], self.unknown
+        )

--- a/coilsnake/modules/eb/TitleScreenModule.py
+++ b/coilsnake/modules/eb/TitleScreenModule.py
@@ -4,6 +4,8 @@ from coilsnake.model.common.blocks import Block
 from coilsnake.model.eb.blocks import EbCompressibleBlock
 from coilsnake.model.eb.graphics import EbGraphicTileset, EbTileArrangement
 from coilsnake.model.eb.palettes import EbPalette
+from coilsnake.model.eb.title_screen import TitleScreenLayoutEntry, \
+    CHARS_NUM_TILES
 from coilsnake.modules.eb.EbModule import EbModule
 from coilsnake.util.common.image import open_indexed_image
 from coilsnake.util.common.yml import yml_dump, yml_load
@@ -35,7 +37,6 @@ CHARS_PALETTE_POINTER = 0x3F492
 # Characters data parameters
 CHARS_SUBPALETTE_LENGTH = 16
 CHARS_NUM_ANIM_SUBPALETTES = 14
-CHARS_NUM_TILES = 1024
 CHARS_TILESET_BPP = 4
 
 # Commmon parameters
@@ -579,63 +580,3 @@ class TitleScreenModule(EbModule):
             block=rom, offset=pointer, pointer=to_snes_address(new_offset)
         )
         return new_offset
-
-
-class TitleScreenLayoutEntry(object):
-
-    SINGLE_FLAG = 0x01
-    FINAL_FLAG = 0x80
-
-    def __init__(self, x=0, y=0, tile=0, flags=0, unknown=12):
-        self.x = x
-        self.y = y
-        self.tile = tile
-        self.flags = flags
-        self.unknown = unknown
-
-    def from_block(self, block, offset=0):
-        y = block[offset]
-        self.y = y if y < 128 else -(256-y)  # Read signed value
-        tile_bytes = block.read_multi(offset+1, 2)
-        self.tile = tile_bytes & (CHARS_NUM_TILES - 1)
-        self.unknown = tile_bytes >> (CHARS_NUM_TILES - 1).bit_length()
-        x = block[offset+3]
-        self.x = x if x < 128 else -(256-x)  # Read signed value
-        self.flags = block[offset+4]
-
-    def to_block(self, block, offset=0):
-        block[offset] = self.y if self.y >= 0 else self.y+256
-        block.write_multi(
-            offset+1,
-            self.tile | self.unknown << (CHARS_NUM_TILES - 1).bit_length(), 2
-        )
-        block[offset+3] = self.x if self.x >= 0 else self.x+256
-        block[offset+4] = self.flags
-
-    @staticmethod
-    def block_size():
-        return 5
-
-    def is_single(self):
-        return (self.flags & self.SINGLE_FLAG) == 0
-
-    def set_single(self, single=True):
-        if single:
-            self.flags |= self.SINGLE_FLAG
-        else:
-            self.flags &= ~self.SINGLE_FLAG
-
-    def is_final(self):
-        return (self.flags & self.FINAL_FLAG) != 0
-
-    def set_final(self, final=True):
-        if final:
-            self.flags |= self.FINAL_FLAG
-        else:
-            self.flags &= ~self.FINAL_FLAG
-
-    def __str__(self):
-        return "<tile={}, x={}, y={}, flags={}, unknown={}>".format(
-            self.tile & (CHARS_NUM_TILES - 1), self.x, self.y,
-            bin(self.flags)[2:], self.unknown
-        )

--- a/coilsnake/modules/eb/TitleScreenModule.py
+++ b/coilsnake/modules/eb/TitleScreenModule.py
@@ -1,0 +1,254 @@
+import logging
+
+from coilsnake.model.eb.blocks import EbCompressibleBlock
+from coilsnake.model.eb.graphics import EbGraphicTileset, EbTileArrangement
+from coilsnake.model.eb.palettes import EbPalette
+from coilsnake.modules.eb.EbModule import EbModule
+from coilsnake.util.eb.pointer import from_snes_address, read_asm_pointer
+
+log = logging.getLogger(__name__)
+
+BG_TILESET_POINTER = 0xebf2
+BG_ARRANGEMENT_POINTER = 0xec1d
+BG_ANIM_PALETTE_POINTER = 0xec9d
+BG_PALETTE_POINTER = 0xecc6
+
+BG_ARRANGEMENT_WIDTH = 32
+BG_ARRANGEMENT_HEIGHT = 28
+BG_SUBPALETTE_LENGTH = 256
+BG_NUM_ANIM_SUBPALETTES = 20
+BG_NUM_TILES = 256
+BG_TILESET_BPP = 8
+
+CHARS_TILESET_POINTER = 0xEC49
+CHARS_ANIM_PALETTES_POINTER = 0xEC83
+CHARS_PALETTE_POINTER = 0x3F492
+
+CHARS_SUBPALETTE_LENGTH = 16
+CHARS_NUM_ANIM_SUBPALETTES = 14
+CHARS_NUM_TILES = 1024
+CHARS_TILESET_BPP = 4
+
+ANIM_SUBPALETTE_LENGTH = 16
+
+NUM_ANIM_FRAMES = BG_NUM_ANIM_SUBPALETTES + CHARS_NUM_ANIM_SUBPALETTES
+NUM_CHARS = 9
+NUM_SUBPALETTES = 1
+
+ANIM_DATA_TABLE_POINTER = 0x21CF9D
+ANIM_DATA_POINTER_OFFSET = 0x210000
+
+
+def decompress_block(rom, block, pointer):
+    block.from_compressed_block(
+        block=rom,
+        offset=from_snes_address(read_asm_pointer(rom, pointer))
+    )
+
+
+class TitleScreenModule(EbModule):
+    NAME = "Title Screen"
+    FREE_RANGES = []
+
+    def __init__(self):
+        super(TitleScreenModule, self).__init__()
+
+        # Background data (includes the central "B", the copyright
+        # notice and the glow around the letters)
+        self.bg_tileset = EbGraphicTileset(num_tiles=BG_NUM_TILES)
+        self.bg_arrangement = EbTileArrangement(
+            width=BG_ARRANGEMENT_WIDTH, height=BG_ARRANGEMENT_HEIGHT
+        )
+        self.bg_anim_palette = EbPalette(
+            num_subpalettes=BG_NUM_ANIM_SUBPALETTES,
+            subpalette_length=ANIM_SUBPALETTE_LENGTH)
+        self.bg_palette = EbPalette(
+            num_subpalettes=NUM_SUBPALETTES,
+            subpalette_length=BG_SUBPALETTE_LENGTH
+        )
+
+        # Characters data (the title screen's animated letters)
+        self.chars_tileset = EbGraphicTileset(num_tiles=CHARS_NUM_TILES)
+        self.chars_anim_palette = EbPalette(
+            num_subpalettes=CHARS_NUM_ANIM_SUBPALETTES,
+            subpalette_length=ANIM_SUBPALETTE_LENGTH
+        )
+        self.chars_palette = EbPalette(
+            num_subpalettes=NUM_SUBPALETTES,
+            subpalette_length=CHARS_SUBPALETTE_LENGTH
+        )
+
+        self.anim_data = []
+
+    def read_from_rom(self, rom):
+        self.read_background_data_from_rom(rom)
+        self.read_chars_data_from_rom(rom)
+        self.read_anim_data_from_rom(rom)
+
+        # Add the last frame of the characters' animated palette into
+        # the background static palette.
+        bg_palette = self.bg_palette.list()
+        bg_palette[0x80*3:(0x80+ANIM_SUBPALETTE_LENGTH)*3] =\
+            self.chars_anim_palette.get_subpalette(
+                CHARS_NUM_ANIM_SUBPALETTES-1
+            ).list()
+        self.bg_palette.from_list(bg_palette)
+
+    def read_background_data_from_rom(self, rom):
+        with EbCompressibleBlock() as block:
+            # Read the background tileset data
+            decompress_block(rom, block, BG_TILESET_POINTER)
+            self.bg_tileset.from_block(
+                block=block, offset=0, bpp=BG_TILESET_BPP
+            )
+
+            # Read the background tile arrangement data
+            decompress_block(rom, block, BG_ARRANGEMENT_POINTER)
+            self.bg_arrangement.from_block(block=block, offset=0)
+
+            # Read the background palette data
+            # The decompressed data is smaller than the expected value,
+            # so it is extended with black entries.
+            decompress_block(rom, block, BG_PALETTE_POINTER)
+            block.from_array(block.to_array() + [0] * (0x200 - len(block)))
+            self.bg_palette.from_block(block=block, offset=0)
+
+            # Read the background animated palette data
+            # Each subpalette corresponds to an animation frame.
+            decompress_block(rom, block, BG_ANIM_PALETTE_POINTER)
+            self.bg_anim_palette.from_block(block=block, offset=0)
+
+    def read_chars_data_from_rom(self, rom):
+        with EbCompressibleBlock() as block:
+            # Read the background tileset data
+            decompress_block(rom, block, CHARS_TILESET_POINTER)
+            self.chars_tileset.from_block(
+                block=block, offset=0, bpp=CHARS_TILESET_BPP
+            )
+
+            # Read the background palette data
+            decompress_block(rom, block, CHARS_PALETTE_POINTER)
+            self.chars_palette.from_block(block=block, offset=0)
+
+            # Read the background animated palette data
+            # Each subpalette corresponds to an animation frame.
+            decompress_block(rom, block, CHARS_ANIM_PALETTES_POINTER)
+            self.chars_anim_palette.from_block(block=block, offset=0)
+
+    def read_anim_data_from_rom(self, rom):
+        self.anim_data = []
+        for char in xrange(NUM_CHARS):
+            char_data = []
+            offset = ANIM_DATA_POINTER_OFFSET + rom.read_multi(
+                ANIM_DATA_TABLE_POINTER + char*2, 2
+            )
+            while True:
+                entry = TitleScreenAnimEntry()
+                entry.from_block(rom, offset)
+                char_data.append(entry)
+                offset += 5
+                if entry.is_final():
+                    break
+            self.anim_data.append(char_data)
+
+    def write_to_rom(self, rom):
+        pass
+
+    def read_from_project(self, resource_open):
+        pass
+
+    def write_to_project(self, resource_open):
+        # Write out the background's animated frames
+        frame_path_format = "TitleScreen/Background/{:02d}"
+        for frame in xrange(NUM_ANIM_FRAMES):
+            palette = EbPalette(NUM_SUBPALETTES, BG_SUBPALETTE_LENGTH)
+            if frame < CHARS_NUM_ANIM_SUBPALETTES:
+                colors = [0] * BG_SUBPALETTE_LENGTH * 3
+                colors[0x80 * 3:(0x80 + ANIM_SUBPALETTE_LENGTH) * 3] = \
+                    self.chars_anim_palette.get_subpalette(frame).list()
+            else:
+                colors = self.bg_palette.list()
+                colors[0x70 * 3:(0x70 + ANIM_SUBPALETTE_LENGTH) * 3] = \
+                    self.bg_anim_palette.get_subpalette(
+                        frame - CHARS_NUM_ANIM_SUBPALETTES
+                    ).list()
+            palette.from_list(colors)
+            with resource_open(frame_path_format.format(frame), "png") as f:
+                image = self.bg_arrangement.image(self.bg_tileset, palette)
+                image.save(f)
+
+        # Write out the background's "initial flash"
+        with resource_open(
+            "TitleScreen/Background/InitialFlash", "png"
+        ) as f:
+            palette = EbPalette(
+                num_subpalettes=NUM_SUBPALETTES,
+                subpalette_length=BG_SUBPALETTE_LENGTH,
+                rgb_list=[0xFF] * 128 * 3 + [0x0] * 128 * 3
+            )
+            image = self.bg_arrangement.image(self.bg_tileset, palette)
+            image.save(f)
+
+        # Write out the background's static look
+        with resource_open(
+            "TitleScreen/Background/Static", "png"
+        ) as f:
+            image = self.bg_arrangement.image(self.bg_tileset, self.bg_palette)
+            image.save(f)
+
+        # Write out the characters' animation
+        for c, char_data in enumerate(self.anim_data):
+            arrangement = EbTileArrangement(3, 6)
+            for e, entry in enumerate(char_data):
+                tile = entry.tile & (CHARS_NUM_TILES - 1)
+                x = (entry.x+16)/8
+                y = (entry.y+24)/8
+                arrangement[x, y].tile = tile
+                if entry.is_border():
+                    arrangement[x+1, y].tile = tile + 1
+                    arrangement[x, y+1].tile = tile + 16
+                    arrangement[x+1, y+1].tile = tile + 17
+
+            for p in xrange(CHARS_NUM_ANIM_SUBPALETTES):
+                with resource_open(
+                    "TitleScreen/Chars/{}/{}".format(c, p), "png"
+                ) as f:
+                    image = arrangement.image(
+                        self.chars_tileset,
+                        self.chars_anim_palette.get_subpalette(p)
+                    )
+                    image.save(f)
+
+    def upgrade_project(
+            self, old_version, new_version, rom, resource_open_r,
+            resource_open_w, resource_delete):
+        pass
+
+
+class TitleScreenAnimEntry(object):
+
+    def __init__(self, x=0, y=0, tile=0, flags=0):
+        self.x = x
+        self.y = y
+        self.tile = tile
+        self.flags = flags
+
+    def from_block(self, block, offset=0):
+        y = block[offset]
+        self.y = y if y < 128 else -(256-y)
+        self.tile = block.read_multi(offset+1, 2)
+        x = block[offset+3]
+        self.x = x if x < 128 else -(256-x)
+        self.flags = block[offset+4]
+
+    def is_border(self):
+        return (self.flags & 0x01) != 0
+
+    def is_final(self):
+        return (self.flags & 0x80) != 0
+
+    def __str__(self):
+        return "<tile={}, x={}, y={}, flags={}, unknown={}>".format(
+            self.tile & (CHARS_NUM_TILES - 1), self.x, self.y,
+            bin(self.flags)[2:], self.tile >> 10
+        )

--- a/coilsnake/util/common/project.py
+++ b/coilsnake/util/common/project.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 # format. Version numbers are necessary because the format of data files may
 # change between versions of CoilSnake.
 
-FORMAT_VERSION = 8
+FORMAT_VERSION = 9
 
 # Names for each version, corresponding the the CS version
 VERSION_NAMES = {
@@ -23,7 +23,8 @@ VERSION_NAMES = {
     5: "2.0.4",
     6: "2.1",
     7: "2.2",
-    8: "2.3.1"
+    8: "2.3.1",
+    9: "2.4"
 }
 
 # The default project filename


### PR DESCRIPTION
This seeks to address issue #17. It provides a way to edit the title screen data by exporting it to a set of PNG images representing animation frames and a YAML file describing characters' positions. Since the title screen is animated simply by swapping palettes, it is not necessary to have the same image in every frame - it simply needs to be the same size and to have a palette with the same number of colors. So far, the letters' sliding-in animation cannot be controlled, nor can the speed at which frames are played.

This is still a rather cumbersome approach, but it has the advantage of allowing editing through graphics editors instead of relying on JHack's editor.