### PR TITLE
Death Screen Module

### DIFF
--- a/coilsnake/assets/modulelist.txt
+++ b/coilsnake/assets/modulelist.txt
@@ -21,6 +21,7 @@ eb.WindowGraphicsModule
 eb.BattleBgModule
 eb.CompressedGraphicsModule
 eb.EnemyModule
+eb.DeathScreenModule
 eb.TitleScreenModule
 eb.TilesetModule
 smb.TextModule

--- a/coilsnake/assets/modulelist.txt
+++ b/coilsnake/assets/modulelist.txt
@@ -11,6 +11,7 @@ eb.MiscTablesModule
 eb.ExpandedTablesModule
 eb.SwirlModule
 eb.TownMapIconModule
+eb.DeathScreenModule
 eb.SoundStoneModule
 eb.MapModule
 eb.MapEnemyModule
@@ -21,7 +22,6 @@ eb.WindowGraphicsModule
 eb.BattleBgModule
 eb.CompressedGraphicsModule
 eb.EnemyModule
-eb.DeathScreenModule
 eb.TitleScreenModule
 eb.TilesetModule
 smb.TextModule

--- a/coilsnake/model/eb/graphics.py
+++ b/coilsnake/model/eb/graphics.py
@@ -254,7 +254,7 @@ class EbTileArrangement(EqualityMixin):
     def block_size(self):
         return 2 * sum([len(x) for x in self.arrangement])
 
-    def to_image(self, image, tileset, palette):
+    def to_image(self, image, tileset, palette, ignore_subpalettes=False):
         palette.to_image(image)
         image_data = image.load()
         offset_y = 0
@@ -262,7 +262,10 @@ class EbTileArrangement(EqualityMixin):
             offset_x = 0
             for item in row:
                 tile = tileset[item.tile]
-                palette_offset = item.subpalette * palette.subpalette_length
+                if ignore_subpalettes:
+                    palette_offset = 0
+                else:
+                    palette_offset = item.subpalette*palette.subpalette_length
                 for tile_y in xrange(tileset.tile_height):
                     for tile_x in xrange(tileset.tile_width):
                         pixel_x, pixel_y = tile_x, tile_y
@@ -274,11 +277,11 @@ class EbTileArrangement(EqualityMixin):
                 offset_x += tileset.tile_width
             offset_y += tileset.tile_height
 
-    def image(self, tileset, palette):
+    def image(self, tileset, palette, ignore_subpalettes=False):
         image = Image.new("P", (self.width * tileset.tile_width,
                                 self.height * tileset.tile_height),
                           None)
-        self.to_image(image, tileset, palette)
+        self.to_image(image, tileset, palette, ignore_subpalettes)
         return image
 
     def from_image(self, image, tileset, palette, no_flip=False):

--- a/coilsnake/modules/eb/DeathScreenModule.py
+++ b/coilsnake/modules/eb/DeathScreenModule.py
@@ -1,0 +1,135 @@
+import logging
+
+from coilsnake.model.eb.blocks import EbCompressibleBlock
+from coilsnake.model.eb.graphics import EbGraphicTileset, EbTileArrangement
+from coilsnake.model.eb.palettes import EbPalette
+from coilsnake.modules.eb.EbModule import EbModule
+from coilsnake.util.common.image import open_indexed_image
+from coilsnake.util.common.yml import yml_dump, yml_load
+from coilsnake.util.eb.pointer import from_snes_address, read_asm_pointer, \
+    write_asm_pointer, to_snes_address
+
+log = logging.getLogger(__name__)
+
+TILESET_POINTER = 0x04C32F
+ARRANGEMENT_POINTER = 0x04C388
+PALETTE_POINTER = 0x04C3C3
+
+ARRANGEMENT_WIDTH = 32
+ARRANGEMENT_HEIGHT = 32
+NUM_SUBPALETTES = 8
+NUM_TILES = 2048
+TILE_WIDTH = 8
+TILE_HEIGHT = 8
+TILESET_BPP = 4
+SUBPALETTE_LENGTH = 16
+
+DEATH_SCREEN_PATH = "Logos/DeathScreen"
+DEATH_SCREEN_SUBPALETTES_PATH = "Logos/DeathScreen_palettes"
+
+
+class DeathScreenModule(EbModule):
+    """Extracts the death screen data from EarthBound."""
+
+    NAME = "Death Screen"
+    FREE_RANGES = []
+
+    def __init__(self):
+        super(DeathScreenModule, self).__init__()
+
+        self.tileset = EbGraphicTileset(
+            num_tiles=NUM_TILES, tile_width=TILE_WIDTH, tile_height=TILE_HEIGHT
+        )
+        self.arrangement = EbTileArrangement(
+            width=ARRANGEMENT_WIDTH, height=ARRANGEMENT_HEIGHT
+        )
+        self.palette = EbPalette(
+            num_subpalettes=NUM_SUBPALETTES,
+            subpalette_length=SUBPALETTE_LENGTH
+        )
+
+    def read_from_rom(self, rom):
+        with EbCompressibleBlock() as block:
+            # Read the tileset data
+            block.from_compressed_block(
+                block=rom, offset=from_snes_address(
+                    read_asm_pointer(rom, TILESET_POINTER)
+                )
+            )
+            self.tileset.from_block(block=block, offset=0, bpp=TILESET_BPP)
+
+            # Read the arrangement data
+            block.from_compressed_block(
+                block=rom, offset=from_snes_address(
+                    read_asm_pointer(rom, ARRANGEMENT_POINTER)
+                )
+            )
+            self.arrangement.from_block(block=block, offset=0)
+
+            # Read the palette data
+            block.from_compressed_block(
+                block=rom, offset=from_snes_address(
+                    read_asm_pointer(rom, PALETTE_POINTER)
+                )
+            )
+            self.palette.from_block(block=block, offset=0)
+
+    def write_to_rom(self, rom):
+        # Write the tileset data
+        block_size = self.tileset.block_size(bpp=TILESET_BPP)
+        with EbCompressibleBlock(block_size) as block:
+            self.tileset.to_block(block=block, offset=0, bpp=TILESET_BPP)
+            self._write_compressed_block(rom, block, TILESET_POINTER)
+
+        # Write the tile arrangement data
+        block_size = self.arrangement.block_size()
+        with EbCompressibleBlock(block_size) as block:
+            self.arrangement.to_block(block=block, offset=0)
+            self._write_compressed_block(rom, block, ARRANGEMENT_POINTER)
+
+        # Write the palette data
+        block_size = self.palette.block_size()
+        with EbCompressibleBlock(block_size) as block:
+            self.palette.to_block(block=block, offset=0)
+            self._write_compressed_block(
+                rom, block, PALETTE_POINTER
+            )
+
+    def read_from_project(self, resource_open):
+        with resource_open(DEATH_SCREEN_PATH, "png") as f:
+            image = open_indexed_image(f)
+            self.arrangement.from_image(image, self.tileset, self.palette)
+        with resource_open(DEATH_SCREEN_SUBPALETTES_PATH, "yaml") as f:
+            subpalettes = yml_load(f)
+            for subpalette, tiles in subpalettes.items():
+                for x, y in tiles:
+                    self.arrangement[x, y].subpalette = subpalette
+
+    def write_to_project(self, resource_open):
+        with resource_open(DEATH_SCREEN_PATH, "png") as f:
+            image = self.arrangement.image(self.tileset, self.palette, True)
+            image.save(f)
+        with resource_open(DEATH_SCREEN_SUBPALETTES_PATH, "yaml") as f:
+            subpalettes = {}
+            for x in range(ARRANGEMENT_WIDTH):
+                for y in range(ARRANGEMENT_HEIGHT):
+                    subpalette = self.arrangement[x, y].subpalette
+                    if subpalette not in subpalettes:
+                        subpalettes[subpalette] = []
+                    subpalettes[subpalette].append((x, y))
+            yml_dump(subpalettes, f, None)
+
+    def upgrade_project(
+            self, old_version, new_version, rom, resource_open_r,
+            resource_open_w, resource_delete):
+        if old_version < 9:
+            self.read_from_rom(rom)
+            self.write_to_project(resource_open_w)
+
+    @staticmethod
+    def _write_compressed_block(rom, compressed_block, pointer):
+        compressed_block.compress()
+        new_offset = rom.allocate(data=compressed_block)
+        write_asm_pointer(
+            block=rom, offset=pointer, pointer=to_snes_address(new_offset)
+        )

--- a/coilsnake/modules/eb/DeathScreenModule.py
+++ b/coilsnake/modules/eb/DeathScreenModule.py
@@ -32,7 +32,11 @@ class DeathScreenModule(EbModule):
     """Extracts the death screen data from EarthBound."""
 
     NAME = "Death Screen"
-    FREE_RANGES = []
+    FREE_RANGES = [
+        (0x21cfaf, 0x21d4f3),  # Tileset
+        (0x21d4f4, 0x21d5e7),  # Palette
+        (0x21d5e8, 0x21d6e1)  # Arrangement
+    ]
 
     def __init__(self):
         super(DeathScreenModule, self).__init__()

--- a/coilsnake/modules/eb/DeathScreenModule.py
+++ b/coilsnake/modules/eb/DeathScreenModule.py
@@ -103,7 +103,7 @@ class DeathScreenModule(EbModule):
         with resource_open(DEATH_SCREEN_PATH, "png") as f:
             image = open_indexed_image(f)
             self.arrangement.from_image(image, self.tileset, self.palette)
-        with resource_open(DEATH_SCREEN_SUBPALETTES_PATH, "yaml") as f:
+        with resource_open(DEATH_SCREEN_SUBPALETTES_PATH, "yml") as f:
             subpalettes = yml_load(f)
             for subpalette, tiles in subpalettes.items():
                 for x, y in tiles:
@@ -113,7 +113,7 @@ class DeathScreenModule(EbModule):
         with resource_open(DEATH_SCREEN_PATH, "png") as f:
             image = self.arrangement.image(self.tileset, self.palette, True)
             image.save(f)
-        with resource_open(DEATH_SCREEN_SUBPALETTES_PATH, "yaml") as f:
+        with resource_open(DEATH_SCREEN_SUBPALETTES_PATH, "yml") as f:
             subpalettes = {}
             for x in range(ARRANGEMENT_WIDTH):
                 for y in range(ARRANGEMENT_HEIGHT):

--- a/coilsnake/modules/eb/TitleScreenModule.py
+++ b/coilsnake/modules/eb/TitleScreenModule.py
@@ -358,7 +358,6 @@ class TitleScreenModule(EbModule):
                 )
 
     def read_chars_data_from_project(self, resource_open):
-
         # Read the characters positions
         with resource_open(CHARS_POSITIONS_PATH, "yml") as f:
             chars_positions = yml_load(f)


### PR DESCRIPTION
Adds a Death Screen (Game Over) module to CoilSnake that can be used to edit the Death Screen's background image.

Currently the image is saved to the `Logos/` directory as I wasn't sure what the best location for it would be.

Addresses issue #81.