### PR TITLE
Adjust profile OptionMenu to align with other gui elements

### DIFF
--- a/coilsnake/ui/gui.py
+++ b/coilsnake/ui/gui.py
@@ -677,8 +677,9 @@ Please configure Java in the Settings menu.""")
         profile_var = StringVar(profile_frame)
 
         profile = OptionMenu(profile_frame, profile_var, "", command=tmp_select)
-        profile["width"] = 26
-        profile.pack(side=LEFT, fill=BOTH, expand=1)
+        profile["width"] = 25
+        profile.pack(side=LEFT, fill=BOTH, expand=1, ipadx=1)
+        
         self.components.append(profile)
 
         def tmp_reload_options(selected_profile_name=None):
@@ -721,7 +722,7 @@ Please configure Java in the Settings menu.""")
                 tmp_reload_options()
                 self.preferences.save()
 
-        button = Button(profile_frame, text="Save", width=5, command=tmp_save)
+        button = Button(profile_frame, text="Save", width=6, command=tmp_save)
         button.pack(side=LEFT, fill=BOTH, expand=1)
         self.components.append(button)
 


### PR DESCRIPTION
Tested on Windows 10.
It seems like a longer term fix would be to use a fixed grid to align these elements, but this gets us pretty close to having them align.

Before:
![image](https://user-images.githubusercontent.com/12491965/27158311-8a9c75ce-5123-11e7-9e49-6afe3517af23.png)

After:
![image](https://user-images.githubusercontent.com/12491965/27158276-6d290a98-5123-11e7-9342-1ad17809c782.png)
