### PR TITLE
Stabilize compilation across python versions.

### DIFF
--- a/coilsnake/model/eb/sprites.py
+++ b/coilsnake/model/eb/sprites.py
@@ -325,7 +325,7 @@ class SpriteGroup(object):
 
         # Write each sprite
         sprite_offsets = dict()
-        for i, (sprite_hash, sprite) in enumerate(unique_sprites.iteritems()):
+        for i, (sprite_hash, sprite) in enumerate(sorted(unique_sprites.iteritems())):
             sprite.to_block(rom, offset)
             sprite_offsets[sprite_hash] = offset
             offset += sprite.block_size()

--- a/coilsnake/modules/eb/MiscTextModule.py
+++ b/coilsnake/modules/eb/MiscTextModule.py
@@ -3,7 +3,6 @@ from coilsnake.modules.eb.EbModule import EbModule
 from coilsnake.util.common.yml import yml_load, yml_dump
 from coilsnake.util.eb.pointer import read_asm_pointer, from_snes_address, write_asm_pointer, to_snes_address
 
-
 class EbMiscTextAsmPointer(object):
     def __init__(self, asm_pointer_loc):
         self.asm_pointer_loc = asm_pointer_loc
@@ -205,8 +204,8 @@ class MiscTextModule(EbModule):
             self.data[category_name] = category_data
 
     def write_to_rom(self, rom):
-        for category_name, category in MISC_TEXT.iteritems():
-            for item_name, item in category.iteritems():
+        for category_name, category in sorted(MISC_TEXT.iteritems()):
+            for item_name, item in sorted(category.iteritems()):
                 item.to_block(rom, self.data[category_name][item_name])
 
     def read_from_project(self, resource_open):

--- a/coilsnake/util/eb/graphics.py
+++ b/coilsnake/util/eb/graphics.py
@@ -132,5 +132,7 @@ def write_8bpp_graphic_to_block(source, target, offset, x=0, y=0):
 def hash_tile(tile):
     csum = 0
     for col in tile:
-        csum = crc32(col, csum)
+        # Generate same crc across python versions
+        # https://docs.python.org/3/library/zlib.html#zlib.crc32
+        csum = crc32(col, csum) & 0xffffffff
     return csum


### PR DESCRIPTION
Sort access to dictionaries when outputting to Rom in order to stabilize output in the face of dictionary implementation changes.
Generate the same CRC32 whether on Python 2 or 3.