### PR TITLE
Don't skip first color when matching SpriteGroup palettes

### DIFF
--- a/coilsnake/modules/eb/SpriteGroupModule.py
+++ b/coilsnake/modules/eb/SpriteGroupModule.py
@@ -84,7 +84,7 @@ class SpriteGroupModule(EbModule):
 
                 # Assign the palette number to the sprite
                 for j in range(8):
-                    if palette.list()[3:] == self.palette_table[j][0].list()[3:]:
+                    if palette.list() == self.palette_table[j][0].list():
                         group.palette = j
                         break
                 else:


### PR DESCRIPTION
SpriteGroups would be incorrectly matched with the underlying palette
because the palette matching code skipped the first color in the
palette. This resulted in SpriteGroups with palette 6 being written back
to the Rom during compilation as palette 5 because the two palettes only
differed by the first color in the palette.

The fix is to simply not skip the first color when performing the
palette matching.

mrtenda thinks it was done this way because some programs were
problematic in handling palettized png files and would disregard or
modify the first color in the palette.