### PR TITLE
Majority of python-futurize stage 2 fixers

### DIFF
--- a/coilsnake/exceptions/common/exceptions.py
+++ b/coilsnake/exceptions/common/exceptions.py
@@ -101,7 +101,7 @@ class TableSchemaError(EqualityMixin, StringRepresentationMixin, CoilSnakeError)
         self.cause = cause
 
     def __str__(self):
-        return "{}: Error while parsing \"{}\":\n{}".format(self.__class__.__name__, self.field, unicode(self.cause))
+        return "{}: Error while parsing \"{}\":\n{}".format(self.__class__.__name__, self.field, str(self.cause))
 
 
 class TableError(EqualityMixin, StringRepresentationMixin, CoilSnakeError):
@@ -119,6 +119,6 @@ class TableError(EqualityMixin, StringRepresentationMixin, CoilSnakeError):
             str_rep += " in entry #{}".format(self.entry)
         if self.table_name is not None:
             str_rep += " in table \"{}\"".format(self.table_name)
-        str_rep += ":\n" + unicode(self.cause)
+        str_rep += ":\n" + str(self.cause)
 
         return str_rep

--- a/coilsnake/model/common/blocks.py
+++ b/coilsnake/model/common/blocks.py
@@ -1,3 +1,4 @@
+from builtins import object
 import array
 import copy
 import os
@@ -123,7 +124,7 @@ class Block(object):
             raise TypeError("Argument \"key\" had invalid type of %s" % type(key).__name__)
 
     def __setitem__(self, key, item):
-        if isinstance(key, int) and isinstance(item, (int, long)):
+        if isinstance(key, int) and isinstance(item, (int, int)):
             if item < 0 or item > 0xff:
                 raise InvalidArgumentError("Could not write invalid value[%d] as a single byte" % item)
             if key >= self.size:
@@ -311,13 +312,12 @@ class Rom(AllocatableBlock):
     def _setup_rom_post_load(self):
         self.type = self._detect_type()
         if self.type != ROM_TYPE_NAME_UNKNOWN and 'free ranges' in ROM_TYPE_MAP[self.type]:
-            self.unallocated_ranges = map(lambda y: tuple(map(lambda z: int(z, 0), y[1:-1].split(','))),
-                                          ROM_TYPE_MAP[self.type]['free ranges'])
-            self.unallocated_ranges = filter(lambda begin_end: begin_end[1] < self.size, self.unallocated_ranges)
+            self.unallocated_ranges = [tuple([int(z, 0) for z in y[1:-1].split(',')]) for y in ROM_TYPE_MAP[self.type]['free ranges']]
+            self.unallocated_ranges = [begin_end for begin_end in self.unallocated_ranges if begin_end[1] < self.size]
             self.unallocated_ranges.sort()
 
     def _detect_type(self):
-        for type_name, d in ROM_TYPE_MAP.iteritems():
+        for type_name, d in ROM_TYPE_MAP.items():
             offset, data, platform = d['offset'], d['data'], d['platform']
 
             if platform == "SNES":

--- a/coilsnake/model/common/ips.py
+++ b/coilsnake/model/common/ips.py
@@ -1,3 +1,4 @@
+from builtins import object
 from array import array
 
 from coilsnake.exceptions.common.exceptions import CoilSnakeError

--- a/coilsnake/model/common/table.py
+++ b/coilsnake/model/common/table.py
@@ -1,3 +1,4 @@
+from builtins import object
 from abc import abstractmethod
 import logging
 
@@ -132,8 +133,8 @@ class EnumeratedLittleEndianIntegerTableEntry(LittleEndianIntegerTableEntry):
     def create(name, size, values):
         enumeration_class = type("GenericEnum_{}".format(name),
                                  (GenericEnum,),
-                                 dict(zip([unicode(x).upper() for x in values],
-                                          range(len(values)))))
+                                 dict(list(zip([str(x).upper() for x in values],
+                                          range(len(values))))))
         return type(name,
                     (EnumeratedLittleEndianIntegerTableEntry,),
                     {"name": name,
@@ -148,7 +149,7 @@ class EnumeratedLittleEndianIntegerTableEntry(LittleEndianIntegerTableEntry):
             except InvalidArgumentError:
                 raise TableEntryInvalidYmlRepresentationError(
                     "Could not parse invalid string[{}] as [{}]. Valid string values are: {}".format(
-                    yml_rep, cls.name, ', '.join(cls.enumeration_class.values())))
+                    yml_rep, cls.name, ', '.join(list(cls.enumeration_class.values()))))
         elif isinstance(yml_rep, int):
             return super(EnumeratedLittleEndianIntegerTableEntry, cls).from_yml_rep(yml_rep)
         else:
@@ -278,7 +279,7 @@ class RowTableEntry(TableEntry):
 
     @classmethod
     def from_schema_specification(cls, schema_specification, name="CustomRowTableEntry", hidden_columns=set()):
-        schema = map(cls.to_table_entry_class, schema_specification)
+        schema = list(map(cls.to_table_entry_class, schema_specification))
         return cls.from_schema(schema, name, hidden_columns)
 
     @classmethod
@@ -381,7 +382,7 @@ class GenericLittleEndianRowTableEntry(RowTableEntry):
                 raise InvalidArgumentError("Unknown table column type[{}]".format(column_specification["type"]))
 
             try:
-                parameters = dict(map(lambda x: (x, column_specification[x]), parameter_list))
+                parameters = dict([(x, column_specification[x]) for x in parameter_list])
             except KeyError:
                 raise InvalidArgumentError("Column[{}] in table schema not provided with all required attributes[{}]"
                                            .format(column_specification["name"], parameter_list))

--- a/coilsnake/model/common/table.py
+++ b/coilsnake/model/common/table.py
@@ -133,8 +133,8 @@ class EnumeratedLittleEndianIntegerTableEntry(LittleEndianIntegerTableEntry):
     def create(name, size, values):
         enumeration_class = type("GenericEnum_{}".format(name),
                                  (GenericEnum,),
-                                 dict(list(zip([str(x).upper() for x in values],
-                                          range(len(values))))))
+                                 dict(zip([str(x).upper() for x in values],
+                                          range(len(values)))))
         return type(name,
                     (EnumeratedLittleEndianIntegerTableEntry,),
                     {"name": name,
@@ -149,7 +149,7 @@ class EnumeratedLittleEndianIntegerTableEntry(LittleEndianIntegerTableEntry):
             except InvalidArgumentError:
                 raise TableEntryInvalidYmlRepresentationError(
                     "Could not parse invalid string[{}] as [{}]. Valid string values are: {}".format(
-                    yml_rep, cls.name, ', '.join(list(cls.enumeration_class.values()))))
+                    yml_rep, cls.name, ', '.join(cls.enumeration_class.values())))
         elif isinstance(yml_rep, int):
             return super(EnumeratedLittleEndianIntegerTableEntry, cls).from_yml_rep(yml_rep)
         else:

--- a/coilsnake/model/eb/ebp.py
+++ b/coilsnake/model/eb/ebp.py
@@ -1,3 +1,4 @@
+from builtins import object
 import json
 
 from coilsnake.exceptions.common.exceptions import CoilSnakeError

--- a/coilsnake/model/eb/enemy_groups.py
+++ b/coilsnake/model/eb/enemy_groups.py
@@ -106,7 +106,7 @@ class MapEnemyGroupTableEntry(TableEntry):
     def _subgroup_from_yml_rep(cls, subgroup_yml_rep, field_id):
         if not subgroup_yml_rep:
             return []
-        subgroup = [MapEnemySubGroupTableEntry.from_yml_rep(x) for x in subgroup_yml_rep.itervalues()]
+        subgroup = [MapEnemySubGroupTableEntry.from_yml_rep(x) for x in subgroup_yml_rep.values()]
         subgroup_sum = sum([x[0] for x in subgroup])
         if subgroup_sum != 8:
             raise TableSchemaError(field=field_id,

--- a/coilsnake/model/eb/fonts.py
+++ b/coilsnake/model/eb/fonts.py
@@ -1,3 +1,4 @@
+from builtins import object
 from coilsnake.model.eb.blocks import EbCompressibleBlock
 from coilsnake.model.eb.graphics import EbTileArrangement, EbGraphicTileset
 from coilsnake.model.eb.palettes import EbPalette
@@ -65,7 +66,7 @@ class EbFont(object):
 
         if widths_format == "yml":
             widths_dict = yml_load(widths_file)
-            self.character_widths = map(lambda i: widths_dict[i], range(self.tileset.num_tiles_maximum))
+            self.character_widths = [widths_dict[i] for i in range(self.tileset.num_tiles_maximum)]
 
     def image_size(self):
         if self.num_characters == 96:

--- a/coilsnake/model/eb/graphics.py
+++ b/coilsnake/model/eb/graphics.py
@@ -1,3 +1,4 @@
+from builtins import object
 from array import array
 from copy import deepcopy
 

--- a/coilsnake/model/eb/map_tilesets.py
+++ b/coilsnake/model/eb/map_tilesets.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import object
 from functools import partial
 
 from coilsnake.model.common.table import LittleEndianIntegerTableEntry

--- a/coilsnake/model/eb/palettes.py
+++ b/coilsnake/model/eb/palettes.py
@@ -77,7 +77,7 @@ class EbColor(EqualityMixin, StringRepresentationMixin):
     def from_yml_rep(self, yml_rep):
         try:
             self.used = True
-            self.r, self.g, self.b = map(int, yml_rep[1:-1].split(','))
+            self.r, self.g, self.b = list(map(int, yml_rep[1:-1].split(',')))
             self.r &= 0xf8
             self.g &= 0xf8
             self.b &= 0xf8
@@ -207,7 +207,7 @@ class EbPalette(EqualityMixin):
                             i,
                             colors - set(subpalette),  # set of colors not in palette
                             ) for i, subpalette in enumerate(self.subpalettes)]
-        subpalette_info = filter(lambda x: x[1] >= len(x[3]), subpalette_info)
+        subpalette_info = [x for x in subpalette_info if x[1] >= len(x[3])]
 
         if len(subpalette_info) == 0:
             # Not enough room to put these colors in a subpalette

--- a/coilsnake/model/eb/palettes.py
+++ b/coilsnake/model/eb/palettes.py
@@ -77,7 +77,7 @@ class EbColor(EqualityMixin, StringRepresentationMixin):
     def from_yml_rep(self, yml_rep):
         try:
             self.used = True
-            self.r, self.g, self.b = list(map(int, yml_rep[1:-1].split(',')))
+            self.r, self.g, self.b = map(int, yml_rep[1:-1].split(','))
             self.r &= 0xf8
             self.g &= 0xf8
             self.b &= 0xf8

--- a/coilsnake/model/eb/sprites.py
+++ b/coilsnake/model/eb/sprites.py
@@ -1,3 +1,4 @@
+from builtins import object
 from array import array
 
 from PIL import Image
@@ -320,14 +321,14 @@ class SpriteGroup(object):
         unique_sprites, unique_sprite_usages = self.calculate_unique_sprites()
 
         # Find a free area
-        offset = rom.allocate(size=sum([x.block_size() for x in unique_sprites.itervalues()]),
+        offset = rom.allocate(size=sum([x.block_size() for x in unique_sprites.values()]),
                               can_write_to=(lambda y: (y & 0xf) == 0))
         self.bank = to_snes_address(offset) >> 16
         offset_start = offset & 0xffff
 
         # Write each sprite
         sprite_offsets = dict()
-        for i, (sprite_hash, sprite) in enumerate(sorted(unique_sprites.iteritems())):
+        for i, (sprite_hash, sprite) in enumerate(sorted(unique_sprites.items())):
             sprite.to_block(rom, offset)
             sprite_offsets[sprite_hash] = offset
             offset += sprite.block_size()
@@ -381,7 +382,7 @@ class SpriteGroup(object):
                     SpriteGroupCollisionEWWidthEntry.to_yml_rep(self.collision_ew_w),
                 SpriteGroupCollisionEWHeightEntry.name:
                     SpriteGroupCollisionEWHeightEntry.to_yml_rep(self.collision_ew_h),
-                'Swim Flags': map(lambda a_x: a_x[1], self.sprites),
+                'Swim Flags': [a_x[1] for a_x in self.sprites],
                 'Length': self.num_sprites}
 
     def from_yml_rep(self, yml_rep):

--- a/coilsnake/model/eb/swirls.py
+++ b/coilsnake/model/eb/swirls.py
@@ -1,3 +1,4 @@
+from builtins import object
 from PIL import Image, ImageDraw
 
 from coilsnake.exceptions.common.exceptions import InvalidArgumentError

--- a/coilsnake/model/eb/table.py
+++ b/coilsnake/model/eb/table.py
@@ -91,7 +91,7 @@ class EbStandardTextTableEntry(TableEntry):
     def from_yml_rep(cls, yml_rep):
         if isinstance(yml_rep, int):
             yml_rep = str(yml_rep)
-        elif not isinstance(yml_rep, basestring):
+        elif not isinstance(yml_rep, str):
             raise TableEntryInvalidYmlRepresentationError("Could not parse value[{}] of type[{}] as string".format(
                 yml_rep, type(yml_rep).__name__))
 
@@ -123,7 +123,7 @@ class EbStandardNullTerminatedTextTableEntry(EbStandardTextTableEntry):
     def from_yml_rep(cls, yml_rep):
         if isinstance(yml_rep, int):
             yml_rep = str(yml_rep)
-        elif not isinstance(yml_rep, basestring):
+        elif not isinstance(yml_rep, str):
             raise TableEntryInvalidYmlRepresentationError("Could not parse value[{}] of type[{}] as string".format(
                 yml_rep, type(yml_rep).__name__))
 

--- a/coilsnake/model/eb/title_screen.py
+++ b/coilsnake/model/eb/title_screen.py
@@ -1,3 +1,4 @@
+from builtins import object
 CHARS_NUM_TILES = 1024
 
 

--- a/coilsnake/modules/common/GenericModule.py
+++ b/coilsnake/modules/common/GenericModule.py
@@ -1,3 +1,4 @@
+from builtins import object
 class GenericModule(object):
     NAME = "Abstract Generic Module"
     FREE_RANGES = []

--- a/coilsnake/modules/common/PatchModule.py
+++ b/coilsnake/modules/common/PatchModule.py
@@ -56,7 +56,7 @@ class PatchModule(GenericModule):
                     continue
                 elif (ips_desc["Title"] in self.patches) and (self.patches[ips_desc["Title"]].lower() == "enabled"):
                     # First, check that we can apply this
-                    ranges = map(lambda y: tuple(map(lambda z: int(z, 0), y[1:-1].split(','))), ips_desc["Ranges"])
+                    ranges = [tuple([int(z, 0) for z in y[1:-1].split(',')]) for y in ips_desc["Ranges"]]
                     for range in ranges:
                         if not rom.is_unallocated(range):
                             raise CoilSnakeError(

--- a/coilsnake/modules/eb/CharacterSubstitutionsModule.py
+++ b/coilsnake/modules/eb/CharacterSubstitutionsModule.py
@@ -21,12 +21,12 @@ class CharacterSubstitutionsModule(EbModule):
             data = yml_load(f)
 
         if data is not None:
-            for key, value in data.iteritems():
-                if not isinstance(key, basestring):
+            for key, value in data.items():
+                if not isinstance(key, str):
                     raise InvalidUserDataError("String to be replaced is not actually a string: " + key)
                 if len(key) != 1:
                     raise InvalidUserDataError("String to be replaced must be a 1 character long: " + key)
-                if not isinstance(value, basestring):
+                if not isinstance(value, str):
                     raise InvalidUserDataError("String to replace with is not actually a string: " + value)
 
         CharacterSubstitutions.character_substitutions = data

--- a/coilsnake/modules/eb/DeathScreenModule.py
+++ b/coilsnake/modules/eb/DeathScreenModule.py
@@ -105,7 +105,7 @@ class DeathScreenModule(EbModule):
             self.arrangement.from_image(image, self.tileset, self.palette)
         with resource_open(DEATH_SCREEN_SUBPALETTES_PATH, "yml") as f:
             subpalettes = yml_load(f)
-            for subpalette, tiles in subpalettes.items():
+            for subpalette, tiles in list(subpalettes.items()):
                 for x, y in tiles:
                     self.arrangement[x, y].subpalette = subpalette
 

--- a/coilsnake/modules/eb/DeathScreenModule.py
+++ b/coilsnake/modules/eb/DeathScreenModule.py
@@ -105,7 +105,7 @@ class DeathScreenModule(EbModule):
             self.arrangement.from_image(image, self.tileset, self.palette)
         with resource_open(DEATH_SCREEN_SUBPALETTES_PATH, "yml") as f:
             subpalettes = yml_load(f)
-            for subpalette, tiles in list(subpalettes.items()):
+            for subpalette, tiles in subpalettes.items():
                 for x, y in tiles:
                     self.arrangement[x, y].subpalette = subpalette
 

--- a/coilsnake/modules/eb/DoorModule.py
+++ b/coilsnake/modules/eb/DoorModule.py
@@ -39,7 +39,7 @@ class DoorModule(EbModule):
             if not entry:
                 rowOut[x % 32] = None
             else:
-                rowOut[x % 32] = map(lambda z: z.yml_rep(), entry)
+                rowOut[x % 32] = [z.yml_rep() for z in entry]
             if (x % 32) == 31:
                 # Start new row
                 out[y] = rowOut

--- a/coilsnake/modules/eb/EnemyModule.py
+++ b/coilsnake/modules/eb/EnemyModule.py
@@ -224,7 +224,7 @@ class EnemyModule(EbModule):
         with resource_open("enemy_groups", "yml") as f:
             self.enemy_groups = []
             enemy_groups_yml_rep = yml_load(f)
-            for entry in enemy_groups_yml_rep.itervalues():
+            for entry in enemy_groups_yml_rep.values():
                 enemy_group = entry["Enemies"]
                 if type(enemy_group) == dict:
                     enemy_group = [enemy_group[x] for x in sorted(enemy_group.keys())]

--- a/coilsnake/modules/eb/ExpandedTablesModule.py
+++ b/coilsnake/modules/eb/ExpandedTablesModule.py
@@ -1,3 +1,4 @@
+from builtins import object
 import logging
 from coilsnake.model.eb.table import eb_table_from_offset
 from coilsnake.modules.eb.EbModule import EbModule
@@ -32,11 +33,11 @@ class ExpandedTablesModule(EbModule):
             self.tables[table_offset] = eb_table_from_offset(table_offset)
 
     def read_from_rom(self, rom):
-        for offset, table in self.tables.iteritems():
+        for offset, table in self.tables.items():
             table.from_block(rom, from_snes_address(offset))
 
     def write_to_rom(self, rom):
-        for offset, table in self.tables.iteritems():
+        for offset, table in self.tables.items():
             new_table_offset = rom.allocate(size=table.size)
             table.to_block(rom, new_table_offset)
             log.info("Writing table @ " + hex(new_table_offset))
@@ -44,7 +45,7 @@ class ExpandedTablesModule(EbModule):
                 pointer.write(rom, to_snes_address(new_table_offset))
 
     def read_from_project(self, resource_open):
-        for table in self.tables.itervalues():
+        for table in self.tables.values():
             with resource_open(table.name.lower(), "yml") as f:
                 yml_rep = yml_load(f)
                 num_rows = len(yml_rep)
@@ -52,6 +53,6 @@ class ExpandedTablesModule(EbModule):
                 table.from_yml_rep(yml_rep)
 
     def write_to_project(self, resource_open):
-        for table in self.tables.itervalues():
+        for table in self.tables.values():
             with resource_open(table.name.lower(), "yml") as f:
                 table.to_yml_file(f)

--- a/coilsnake/modules/eb/MapModule.py
+++ b/coilsnake/modules/eb/MapModule.py
@@ -84,7 +84,7 @@ class MapModule(EbModule):
             offset = map_addrs[row_number % 8] + ((row_number >> 3) << 8)
             return rom[offset:offset + MAP_WIDTH].to_list()
 
-        self.tiles = map(read_row_data, range(MAP_HEIGHT))
+        self.tiles = list(map(read_row_data, range(MAP_HEIGHT)))
         k = LOCAL_TILESETS_OFFSET
         for i in range(MAP_HEIGHT >> 3):
             for j in range(MAP_WIDTH):
@@ -175,9 +175,7 @@ class MapModule(EbModule):
     def read_from_project(self, resource_open):
         # Read map data
         with resource_open("map_tiles", "map") as f:
-            self.tiles = map(lambda y:
-                             map(lambda x: int(x, 16), y.split(" ")),
-                             f.readlines())
+            self.tiles = [[int(x, 16) for x in y.split(" ")] for y in f.readlines()]
 
         # Read sector data
         with resource_open("map_sectors", "yml") as f:

--- a/coilsnake/modules/eb/MiscTablesModule.py
+++ b/coilsnake/modules/eb/MiscTablesModule.py
@@ -36,7 +36,7 @@ class MiscTablesModule(EbModule):
 
     def __init__(self):
         super(MiscTablesModule, self).__init__()
-        self.tables = map(lambda x: (from_snes_address(x), eb_table_from_offset(x)), self.TABLE_OFFSETS)
+        self.tables = [(from_snes_address(x), eb_table_from_offset(x)) for x in self.TABLE_OFFSETS]
 
     def read_from_rom(self, rom):
         for offset, table in self.tables:

--- a/coilsnake/modules/eb/MiscTextModule.py
+++ b/coilsnake/modules/eb/MiscTextModule.py
@@ -1,3 +1,4 @@
+from builtins import object
 from coilsnake.model.eb.table import EbStandardNullTerminatedTextTableEntry, EbStandardTextTableEntry
 from coilsnake.modules.eb.EbModule import EbModule
 from coilsnake.util.common.yml import yml_load, yml_dump
@@ -197,15 +198,15 @@ class MiscTextModule(EbModule):
         self.data = dict()
 
     def read_from_rom(self, rom):
-        for category_name, category in MISC_TEXT.iteritems():
+        for category_name, category in MISC_TEXT.items():
             category_data = dict()
-            for item_name, item in category.iteritems():
+            for item_name, item in category.items():
                 category_data[item_name] = item.from_block(rom)
             self.data[category_name] = category_data
 
     def write_to_rom(self, rom):
-        for category_name, category in sorted(MISC_TEXT.iteritems()):
-            for item_name, item in sorted(category.iteritems()):
+        for category_name, category in sorted(MISC_TEXT.items()):
+            for item_name, item in sorted(category.items()):
                 item.to_block(rom, self.data[category_name][item_name])
 
     def read_from_project(self, resource_open):

--- a/coilsnake/modules/eb/TilesetModule.py
+++ b/coilsnake/modules/eb/TilesetModule.py
@@ -215,8 +215,8 @@ class TilesetModule(EbModule):
         elif old_version <= 6:
             with resource_open_r("map_palette_settings", "yml") as f:
                 yml_rep = yml_load(f)
-                for map_tileset in yml_rep.itervalues():
-                    for map_palette in map_tileset.itervalues():
+                for map_tileset in yml_rep.values():
+                    for map_palette in map_tileset.values():
                         if "Event Palette" in map_palette:
                             map_palette["Event Palette"] = {
                                 "Colors": map_palette["Event Palette"],

--- a/coilsnake/modules/eb/TitleScreenModule.py
+++ b/coilsnake/modules/eb/TitleScreenModule.py
@@ -419,7 +419,7 @@ class TitleScreenModule(EbModule):
 
                 # Set the new character layouts
                 self.chars_layouts = [[] for _ in xrange(NUM_CHARS)]
-                for c, data in chars_positions.items():
+                for c, data in list(chars_positions.items()):
                     # Get the data from the YAML file
                     x = int(data['x'] // TILE_WIDTH)
                     y = int(data['y'] // TILE_HEIGHT)

--- a/coilsnake/modules/eb/TitleScreenModule.py
+++ b/coilsnake/modules/eb/TitleScreenModule.py
@@ -419,7 +419,7 @@ class TitleScreenModule(EbModule):
 
                 # Set the new character layouts
                 self.chars_layouts = [[] for _ in xrange(NUM_CHARS)]
-                for c, data in list(chars_positions.items()):
+                for c, data in chars_positions.items():
                     # Get the data from the YAML file
                     x = int(data['x'] // TILE_WIDTH)
                     y = int(data['y'] // TILE_HEIGHT)

--- a/coilsnake/tools/damage_calc.py
+++ b/coilsnake/tools/damage_calc.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 from __future__ import print_function
+from __future__ import division
 import argparse
 import os
 import random

--- a/coilsnake/ui/common.py
+++ b/coilsnake/ui/common.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from datetime import datetime
 import logging
 import os

--- a/coilsnake/ui/gui.py
+++ b/coilsnake/ui/gui.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+from builtins import object
 import Tkinter
 from functools import partial
 import logging

--- a/coilsnake/ui/gui_preferences.py
+++ b/coilsnake/ui/gui_preferences.py
@@ -1,3 +1,4 @@
+from builtins import object
 import os
 
 from coilsnake.util.common.yml import yml_load, yml_dump
@@ -48,8 +49,8 @@ class CoilSnakePreferences(object):
 
     def get_profiles(self, tab_name):
         tab = self._get_preferences_profile_tab(tab_name)
-        profiles = tab.keys()
-        if " default" in tab.keys():
+        profiles = list(tab.keys())
+        if " default" in list(tab.keys()):
             profiles.remove(" default")
         return profiles
 

--- a/coilsnake/ui/gui_preferences.py
+++ b/coilsnake/ui/gui_preferences.py
@@ -50,7 +50,7 @@ class CoilSnakePreferences(object):
     def get_profiles(self, tab_name):
         tab = self._get_preferences_profile_tab(tab_name)
         profiles = list(tab.keys())
-        if " default" in list(tab.keys()):
+        if " default" in tab.keys():
             profiles.remove(" default")
         return profiles
 

--- a/coilsnake/ui/widgets.py
+++ b/coilsnake/ui/widgets.py
@@ -1,3 +1,4 @@
+from builtins import object
 import Queue
 from Tkinter import *
 from ttk import *

--- a/coilsnake/util/common/helper.py
+++ b/coilsnake/util/common/helper.py
@@ -1,4 +1,4 @@
-from itertools import izip
+
 
 from coilsnake.exceptions.common.exceptions import MissingUserDataError, InvalidUserDataError, InvalidArgumentError
 
@@ -53,4 +53,4 @@ def lower_if_str(x):
 
 
 def grouped(iterable, n):
-    return izip(*[iter(iterable)]*n)
+    return zip(*[iter(iterable)]*n)

--- a/coilsnake/util/common/project.py
+++ b/coilsnake/util/common/project.py
@@ -1,3 +1,4 @@
+from builtins import object
 import logging
 
 import os

--- a/coilsnake/util/common/type.py
+++ b/coilsnake/util/common/type.py
@@ -1,3 +1,4 @@
+from builtins import object
 class EqualityMixin(object):
     def __eq__(self, other):
         return (isinstance(other, self.__class__)
@@ -24,18 +25,18 @@ class GenericEnum(object):
     def create(name, values):
         return type("{}_GenericEnum".format(name),
                     (GenericEnum,),
-                    dict(zip([str(x).upper() for x in values], range(len(values)))))
+                    dict(list(zip([str(x).upper() for x in values], range(len(values))))))
 
     @classmethod
     def is_valid(cls, val):
-        for k, v in vars(cls).iteritems():
+        for k, v in vars(cls).items():
             if v == val:
                 return True
         return False
 
     @classmethod
     def tostring(cls, val):
-        for k, v in vars(cls).iteritems():
+        for k, v in vars(cls).items():
             if v == val:
                 return k.lower()
         from coilsnake.exceptions.common.exceptions import InvalidArgumentError
@@ -56,10 +57,10 @@ class GenericEnum(object):
 
     @classmethod
     def values(cls):
-        return [x for x in vars(cls).iterkeys() if not x.startswith("_")]
+        return [x for x in vars(cls).keys() if not x.startswith("_")]
 
 
 def enum_class_from_name_list(names):
     return type("CustomEnum",
                 (GenericEnum,),
-                dict(zip([str(x).upper() for x in names], range(len(names)))))
+                dict(list(zip([str(x).upper() for x in names], range(len(names))))))

--- a/coilsnake/util/common/type.py
+++ b/coilsnake/util/common/type.py
@@ -25,7 +25,7 @@ class GenericEnum(object):
     def create(name, values):
         return type("{}_GenericEnum".format(name),
                     (GenericEnum,),
-                    dict(list(zip([str(x).upper() for x in values], range(len(values))))))
+                    dict(zip([str(x).upper() for x in values], range(len(values)))))
 
     @classmethod
     def is_valid(cls, val):
@@ -63,4 +63,4 @@ class GenericEnum(object):
 def enum_class_from_name_list(names):
     return type("CustomEnum",
                 (GenericEnum,),
-                dict(list(zip([str(x).upper() for x in names], range(len(names))))))
+                dict(zip([str(x).upper() for x in names], range(len(names)))))

--- a/coilsnake/util/common/yml.py
+++ b/coilsnake/util/common/yml.py
@@ -33,7 +33,7 @@ def replace_field_in_yml(resource_name, resource_open_r, resource_open_w, key, n
         value_map = dict()
     if new_key is None:
         new_key = key
-    value_map = dict((lower_if_str(k), lower_if_str(v)) for k, v in value_map.iteritems())
+    value_map = dict((lower_if_str(k), lower_if_str(v)) for k, v in value_map.items())
     with resource_open_r(resource_name, "yml") as f:
         data = yml_load(f)
         for i in data:

--- a/coilsnake/util/eb/text.py
+++ b/coilsnake/util/eb/text.py
@@ -1,4 +1,5 @@
-class CharacterSubstitutions:
+from builtins import object
+class CharacterSubstitutions(object):
     character_substitutions = dict()
 
 
@@ -16,7 +17,7 @@ def standard_text_from_block(block, offset, max_length):
 def standard_text_to_byte_list(text, max_length):
     # First, substitute all of the characters
     if CharacterSubstitutions.character_substitutions:
-        for k, v in CharacterSubstitutions.character_substitutions.iteritems():
+        for k, v in CharacterSubstitutions.character_substitutions.items():
             text = text.replace(k, v)
 
     byte_list = []

--- a/tests/coilsnake_test.py
+++ b/tests/coilsnake_test.py
@@ -1,4 +1,5 @@
-from itertools import izip_longest
+from builtins import object
+from itertools import zip_longest
 import tempfile
 
 import os
@@ -12,7 +13,7 @@ TEST_IMAGE_DIR = os.path.join(TEST_DATA_DIR, "images")
 
 
 def assert_files_equal(expected, result):
-    for i in izip_longest(iter(expected), iter(result)):
+    for i in zip_longest(iter(expected), iter(result)):
         eq_(i[0], i[1])
 
 


### PR DESCRIPTION
Ran futurize --stage2 fixers without:
libfuturize.fixes.fix_future_builtins
libfuturize.fixes.fix_future_standard_library
libfuturize.fixes.fix_xrange_with_import

libfuturize.fixes.fix_future_builtins caused some widespread functional
changes I believe due to string handling differences.

libfuturize.fixes.fix_future_standard_library caused issues with the ttk
modules in the gui.

libfuturize.fixes.fix_xrange_with_import resulted in unacceptable
performance degredation.

Command used:
futurize  -f lib2to3.fixes.fix_basestring -f lib2to3.fixes.fix_dict -f
lib2to3.fixes.fix_exec -f lib2to3.fixes.fix_getcwdu -f
lib2to3.fixes.fix_input -f lib2to3.fixes.fix_itertools -f
lib2to3.fixes.fix_itertools_imports -f lib2to3.fixes.fix_filter -f
lib2to3.fixes.fix_long -f lib2to3.fixes.fix_map -f
lib2to3.fixes.fix_nonzero -f lib2to3.fixes.fix_operator -f
lib2to3.fixes.fix_raw_input -f lib2to3.fixes.fix_zip -f
libfuturize.fixes.fix_cmp -f libfuturize.fixes.fix_division -f
libfuturize.fixes.fix_execfile -f
libfuturize.fixes.fix_future_standard_library_urllib -f
libfuturize.fixes.fix_metaclass -f libpasteurize.fixes.fix_newstyle -f
libfuturize.fixes.fix_object -f libfuturize.fixes.fix_unicode_keep_u .
-w -n --no-diffs