### PR TITLE
Updates to setup_exe.py and setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,12 @@
 
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
+import platform
+
+extra_compile_args = []
+
+if platform.system() != "Windows":
+      extra_compile_args = ["-std=c99"]
 
 setup(
     name="coilsnake",
@@ -22,8 +28,10 @@ setup(
         "https://github.com/tripped/ccscript_legacy/tarball/master#egg=ccscript-1.338"
     ],
     ext_modules=[
-        Extension("coilsnake.util.eb.native_comp", ["coilsnake/util/eb/native_comp.c", "coilsnake/util/eb/exhal/compress.c"],
-        extra_compile_args=["-std=c99"],
+        Extension(
+            "coilsnake.util.eb.native_comp",
+            ["coilsnake/util/eb/native_comp.c", "coilsnake/util/eb/exhal/compress.c"],
+            extra_compile_args=extra_compile_args,
         )
     ],
     entry_points={

--- a/setup_exe.py
+++ b/setup_exe.py
@@ -5,6 +5,7 @@ from cx_Freeze import setup, Executable
 
 import os
 import sys
+import platform
 
 # Workaround for tcl/tk with cx_freeze
 # From https://stackoverflow.com/questions/35533803/keyerror-tcl-library-when-i-use-cx-freeze
@@ -44,6 +45,11 @@ base = None
 if sys.platform == "win32":
     base = "Win32GUI"
 
+extra_compile_args = []
+
+if platform.system() != "Windows":
+    extra_compile_args = ["-std=c99"]
+
 setup(      
     name="coilsnake",
     version="3.0",
@@ -53,7 +59,11 @@ setup(
     data_files=data_files,
 
     ext_modules=[
-        Extension("coilsnake.util.eb.native_comp", ["coilsnake/util/eb/native_comp.c"])
+        Extension(
+            "coilsnake.util.eb.native_comp",
+            ["coilsnake/util/eb/native_comp.c", "coilsnake/util/eb/exhal/compress.c"],
+            extra_compile_args=extra_compile_args,
+        )
     ],
     options = {"build_exe": build_exe_options},
     executables = [Executable(


### PR DESCRIPTION
The "-std=99" flag isn't supported by Visual C++. It's technically only a warning, but I feel it's cleaner to not apply it in the first place on Windows.

I forgot to include the exhal dependency in setup_exe.py