### PR TITLE
Change python to python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
 all: coilsnake_lib submodule
 
 install: all
-	python setup.py install
+	python3 setup.py install
 
 test: coilsnake_lib
-	python setup.py test
+	python3 setup.py test
 
 coverage: coilsnake_lib
 	script/coverage.sh
 
 coilsnake_lib:
-	python setup.py build_ext --inplace clean
+	python3 setup.py build_ext --inplace clean
 
 submodule:
 	git submodule init
 	git submodule update
 
 clean:
-	python setup.py clean
+	python3 setup.py clean


### PR DESCRIPTION
The default python on my system was and still is python 2. Seeing as this is a fairly common issue I'd highly recommend replacing the "python" commands with "python3" ones.